### PR TITLE
Backfill all open aredis PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ workflows:
             parameters:
               hiredis: [false, true]
               python_version: ['3.5', '3.6', '3.7', '3.8']
-              redis_version: ['3', '4', '5']
+              redis_version: ['3', '4', '5', '6']
 
       - pytest-cluster:
           name: pytest-<<matrix.python_version>>-cluster-<<matrix.redis_version>>-hiredis-<<matrix.hiredis>>
@@ -63,4 +63,4 @@ workflows:
               hiredis: [false, true]
               python_version: ['3.5', '3.6', '3.7', '3.8']
               # TODO: pin to latest builds
-              redis_version: ['3.2.13', '4.0.14', '5.0.5']
+              redis_version: ['3.2.13', '4.0.14', '5.0.5', '6.0.12']

--- a/aredis/__init__.py
+++ b/aredis/__init__.py
@@ -6,12 +6,12 @@ from aredis.connection import (
 )
 from aredis.pool import ConnectionPool, ClusterConnectionPool
 from aredis.exceptions import (
-    AuthenticationError, BusyLoadingError, ConnectionError,
-    DataError, InvalidResponse, PubSubError, ReadOnlyError,
-    RedisError, ResponseError, TimeoutError, WatchError,
-    CompressError, ClusterDownException, ClusterCrossSlotError,
-    CacheError, ClusterDownError, ClusterError, RedisClusterException,
-    RedisClusterError, ExecAbortError, LockError, NoScriptError
+    AuthenticationFailureError, AuthenticationRequiredError, BusyLoadingError,
+    CacheError, ClusterCrossSlotError, ClusterDownError, ClusterDownException,
+    ClusterError, CompressError, ConnectionError, DataError, ExecAbortError,
+    InvalidResponse, LockError, NoPermissionError, NoScriptError, PubSubError,
+    ReadOnlyError, RedisClusterError, RedisClusterException, RedisError,
+    ResponseError, TimeoutError, WatchError
 )
 
 
@@ -24,10 +24,12 @@ __all__ = [
     'StrictRedis', 'StrictRedisCluster',
     'Connection', 'UnixDomainSocketConnection', 'ClusterConnection',
     'ConnectionPool', 'ClusterConnectionPool',
-    'AuthenticationError', 'BusyLoadingError', 'ConnectionError', 'DataError',
-    'InvalidResponse', 'PubSubError', 'ReadOnlyError', 'RedisError',
-    'ResponseError', 'TimeoutError', 'WatchError',
-    'CompressError', 'ClusterDownException', 'ClusterCrossSlotError',
-    'CacheError', 'ClusterDownError', 'ClusterError', 'RedisClusterException',
-    'RedisClusterError', 'ExecAbortError', 'LockError', 'NoScriptError'
+    'AuthenticationFailureError', 'AuthenticationRequiredError',
+    'BusyLoadingError', 'CacheError', 'ClusterCrossSlotError',
+    'ClusterDownError', 'ClusterDownException', 'ClusterError',
+    'CompressError', 'ConnectionError', 'DataError', 'ExecAbortError',
+    'InvalidResponse', 'LockError', 'NoPermissionError', 'NoScriptError',
+    'PubSubError', 'ReadOnlyError', 'RedisClusterError',
+    'RedisClusterException', 'RedisError', 'ResponseError', 'TimeoutError',
+    'WatchError'
 ]

--- a/aredis/__init__.py
+++ b/aredis/__init__.py
@@ -4,7 +4,7 @@ from aredis.connection import (
     UnixDomainSocketConnection,
     ClusterConnection
 )
-from aredis.pool import ConnectionPool, ClusterConnectionPool
+from aredis.pool import ConnectionPool, ClusterConnectionPool, BlockingConnectionPool
 from aredis.exceptions import (
     AuthenticationFailureError, AuthenticationRequiredError, BusyLoadingError,
     CacheError, ClusterCrossSlotError, ClusterDownError, ClusterDownException,
@@ -23,7 +23,7 @@ VERSION = tuple(map(int, __version__.split('.')))
 __all__ = [
     'StrictRedis', 'StrictRedisCluster',
     'Connection', 'UnixDomainSocketConnection', 'ClusterConnection',
-    'ConnectionPool', 'ClusterConnectionPool',
+    'ConnectionPool', 'ClusterConnectionPool', 'BlockingConnectionPool',
     'AuthenticationFailureError', 'AuthenticationRequiredError',
     'BusyLoadingError', 'CacheError', 'ClusterCrossSlotError',
     'ClusterDownError', 'ClusterDownException', 'ClusterError',

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -152,7 +152,7 @@ class StrictRedis(*mixins):
         """Executes a command and returns a parsed response"""
         pool = self.connection_pool
         command_name = args[0]
-        connection = pool.get_connection()
+        connection = await pool.get_connection()
         try:
             await connection.send_command(*args)
             return await self.parse_response(connection, command_name, **options)

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -100,7 +100,7 @@ class StrictRedis(*mixins):
                  ssl_cert_reqs=None, ssl_ca_certs=None,
                  max_connections=None, retry_on_timeout=False,
                  max_idle_time=0, idle_check_interval=1,
-                 loop=None, **kwargs):
+                 client_name=None, loop=None, **kwargs):
         if not connection_pool:
             kwargs = {
                 'db': db,
@@ -113,6 +113,7 @@ class StrictRedis(*mixins):
                 'decode_responses': decode_responses,
                 'max_idle_time': max_idle_time,
                 'idle_check_interval': idle_check_interval,
+                'client_name': client_name,
                 'loop': loop
             }
             # based on input, setup appropriate connection args

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -92,7 +92,7 @@ class StrictRedis(*mixins):
         return cls(connection_pool=connection_pool)
 
     def __init__(self, host='localhost', port=6379,
-                 db=0, password=None, stream_timeout=None,
+                 db=0, username=None, password=None, stream_timeout=None,
                  connect_timeout=None, connection_pool=None,
                  unix_socket_path=None, encoding='utf-8',
                  decode_responses=False, ssl=False, ssl_context=None,
@@ -104,6 +104,7 @@ class StrictRedis(*mixins):
         if not connection_pool:
             kwargs = {
                 'db': db,
+                'username': username,
                 'password': password,
                 'encoding': encoding,
                 'stream_timeout': stream_timeout,

--- a/aredis/client.py
+++ b/aredis/client.py
@@ -159,10 +159,14 @@ class StrictRedis(*mixins):
             # do not retry when coroutine is cancelled
             connection.disconnect()
             raise
-        except (ConnectionError, TimeoutError) as e:
+        except ConnectionError:
             connection.disconnect()
-            if not connection.retry_on_timeout and isinstance(e, TimeoutError):
+            raise
+        except TimeoutError:
+            connection.disconnect()
+            if not connection.retry_on_timeout:
                 raise
+
             await connection.send_command(*args)
             return await self.parse_response(connection, command_name, **options)
         finally:

--- a/aredis/commands/keys.py
+++ b/aredis/commands/keys.py
@@ -249,7 +249,7 @@ class KeysCommandMixin:
         """
         return await self.execute_command('WAIT', num_replicas, timeout)
 
-    async def scan(self, cursor=0, match=None, count=None):
+    async def scan(self, cursor=0, match=None, count=None, type=None):
         """
         Incrementally return lists of key names. Also return a cursor
         indicating the scan position.
@@ -257,12 +257,16 @@ class KeysCommandMixin:
         ``match`` allows for filtering the keys by pattern
 
         ``count`` allows for hint the minimum number of returns
+
+        ``type`` filters results by a redis type
         """
         pieces = [cursor]
         if match is not None:
             pieces.extend([b('MATCH'), match])
         if count is not None:
             pieces.extend([b('COUNT'), count])
+        if type is not None:
+            pieces.extend([b('TYPE'), type])
         return await self.execute_command('SCAN', *pieces)
 
 

--- a/aredis/commands/strings.py
+++ b/aredis/commands/strings.py
@@ -236,13 +236,16 @@ class StringsCommandMixin:
             time_ms = (time_ms.seconds + time_ms.days * 24 * 3600) * 1000 + ms
         return await self.execute_command('PSETEX', name, time_ms, value)
 
-    async def set(self, name, value, ex=None, px=None, nx=False, xx=False):
+    async def set(self, name, value, ex=None, px=None, keepttl=False, nx=False, xx=False):
         """
         Set the value at key ``name`` to ``value``
 
         ``ex`` sets an expire flag on key ``name`` for ``ex`` seconds.
 
         ``px`` sets an expire flag on key ``name`` for ``px`` milliseconds.
+
+        ``keepttl`` if set to True, retain the time to live associated with the
+            key.
 
         ``nx`` if set to True, set the value at key ``name`` to ``value`` if it
             does not already exist.
@@ -263,6 +266,8 @@ class StringsCommandMixin:
                 px = (px.seconds + px.days * 24 * 3600) * 1000 + ms
             pieces.append(px)
 
+        if keepttl:
+            pieces.append('KEEPTTL')
         if nx:
             pieces.append('NX')
         if xx:

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -367,7 +367,7 @@ class BaseConnection:
     def __init__(self, retry_on_timeout=False, stream_timeout=None,
                  parser_class=DefaultParser, reader_read_size=65535,
                  encoding='utf-8', decode_responses=False,
-                 *, loop=None):
+                 *, client_name=None, loop=None):
         self._parser = parser_class(reader_read_size)
         self._stream_timeout = stream_timeout
         self._reader = None
@@ -381,6 +381,7 @@ class BaseConnection:
         self.encoding = encoding
         self.decode_responses = decode_responses
         self.loop = loop
+        self.client_name = client_name
         # flag to show if a connection is waiting for response
         self.awaiting_response = False
         self.last_active_at = time.time()
@@ -444,6 +445,12 @@ class BaseConnection:
             await self.send_command('SELECT', self.db)
             if nativestr(await self.read_response()) != 'OK':
                 raise ConnectionError('Invalid Database')
+
+        if self.client_name is not None:
+            await self.send_command('CLIENT SETNAME', self.client_name)
+            if nativestr(await self.read_response()) != 'OK':
+                raise ConnectionError('Failed to set client name')
+
         self.last_active_at = time.time()
 
     async def read_response(self):
@@ -573,11 +580,11 @@ class Connection(BaseConnection):
                  db=0, retry_on_timeout=False, stream_timeout=None, connect_timeout=None,
                  ssl_context=None, parser_class=DefaultParser, reader_read_size=65535,
                  encoding='utf-8', decode_responses=False, socket_keepalive=None,
-                 socket_keepalive_options=None, *, loop=None):
+                 socket_keepalive_options=None, *, client_name=None, loop=None):
         super(Connection, self).__init__(retry_on_timeout, stream_timeout,
                                          parser_class, reader_read_size,
                                          encoding, decode_responses,
-                                         loop=loop)
+                                         client_name=client_name, loop=loop)
         self.host = host
         self.port = port
         self.password = password
@@ -626,11 +633,11 @@ class UnixDomainSocketConnection(BaseConnection):
     def __init__(self, path='', password=None,
                  db=0, retry_on_timeout=False, stream_timeout=None, connect_timeout=None,
                  ssl_context=None, parser_class=DefaultParser, reader_read_size=65535,
-                 encoding='utf-8', decode_responses=False, *, loop=None):
+                 encoding='utf-8', decode_responses=False, *, client_name=None, loop=None):
         super(UnixDomainSocketConnection, self).__init__(retry_on_timeout, stream_timeout,
                                                          parser_class, reader_read_size,
                                                          encoding, decode_responses,
-                                                         loop=loop)
+                                                         client_name=client_name, loop=loop)
         self.path = path
         self.db = db
         self.password = password

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -416,8 +416,9 @@ class BaseConnection:
             await self._connect()
         except aredis.compat.CancelledError:
             raise
-        except Exception as exc:
-            raise ConnectionError()
+        except Exception:
+            e = sys.exc_info()[1]
+            raise ConnectionError("Error {} during initial connection: {}".format(type(e), e.args))
         # run any user callbacks. right now the only internal callback
         # is for pubsub channel/pattern resubscription
         for callback in self._connect_callbacks:

--- a/aredis/connection.py
+++ b/aredis/connection.py
@@ -10,13 +10,16 @@ import warnings
 from io import BytesIO
 
 import aredis.compat
-from aredis.exceptions import (ConnectionError, TimeoutError,
+from aredis.exceptions import (AuthenticationFailureError,
+                               AuthenticationRequiredError,
+                               ConnectionError, TimeoutError,
                                RedisError, ExecAbortError,
                                BusyLoadingError, NoScriptError,
                                ReadOnlyError, ResponseError,
                                InvalidResponse, AskError,
                                MovedError, TryAgainError,
-                               ClusterDownError, ClusterCrossSlotError)
+                               ClusterDownError, ClusterCrossSlotError,
+                               NoPermissionError)
 from aredis.utils import b, nativestr, LOOP_DEPRECATED
 
 try:
@@ -154,6 +157,9 @@ class BaseParser:
         'MOVED': MovedError,
         'CLUSTERDOWN': ClusterDownError,
         'CROSSSLOT': ClusterCrossSlotError,
+        'WRONGPASS': AuthenticationFailureError,
+        'NOAUTH': AuthenticationRequiredError,
+        'NOPERM': NoPermissionError,
     }
 
     def parse_error(self, response):
@@ -372,6 +378,7 @@ class BaseConnection:
         self._stream_timeout = stream_timeout
         self._reader = None
         self._writer = None
+        self.username = ''
         self.password = ''
         self.db = ''
         self.pid = os.getpid()
@@ -435,11 +442,16 @@ class BaseConnection:
     async def on_connect(self):
         self._parser.on_connect(self)
 
+        # if a username and a password is specified, authenticate
+        if self.username and self.password:
+            await self.send_command('AUTH', self.username, self.password)
+            if nativestr(await self.read_response()) != 'OK':
+                raise ConnectionError('Failed to set username or password')
         # if a password is specified, authenticate
-        if self.password:
+        elif self.password:
             await self.send_command('AUTH', self.password)
             if nativestr(await self.read_response()) != 'OK':
-                raise ConnectionError('Invalid Password')
+                raise ConnectionError('Failed to set password')
 
         # if a database is specified, switch to it
         if self.db:
@@ -577,7 +589,7 @@ class BaseConnection:
 class Connection(BaseConnection):
     description = 'Connection<host={host},port={port},db={db}>'
 
-    def __init__(self, host='127.0.0.1', port=6379, password=None,
+    def __init__(self, host='127.0.0.1', port=6379, username=None, password=None,
                  db=0, retry_on_timeout=False, stream_timeout=None, connect_timeout=None,
                  ssl_context=None, parser_class=DefaultParser, reader_read_size=65535,
                  encoding='utf-8', decode_responses=False, socket_keepalive=None,
@@ -588,6 +600,7 @@ class Connection(BaseConnection):
                                          client_name=client_name, loop=loop)
         self.host = host
         self.port = port
+        self.username = username
         self.password = password
         self.db = db
         self.ssl_context = ssl_context
@@ -631,7 +644,7 @@ class Connection(BaseConnection):
 class UnixDomainSocketConnection(BaseConnection):
     description = "UnixDomainSocketConnection<path={path},db={db}>"
 
-    def __init__(self, path='', password=None,
+    def __init__(self, path='', username=None, password=None,
                  db=0, retry_on_timeout=False, stream_timeout=None, connect_timeout=None,
                  ssl_context=None, parser_class=DefaultParser, reader_read_size=65535,
                  encoding='utf-8', decode_responses=False, *, client_name=None, loop=None):
@@ -641,6 +654,7 @@ class UnixDomainSocketConnection(BaseConnection):
                                                          client_name=client_name, loop=loop)
         self.path = path
         self.db = db
+        self.username = username
         self.password = password
         self.ssl_context = ssl_context
         self._connect_timeout = connect_timeout

--- a/aredis/exceptions.py
+++ b/aredis/exceptions.py
@@ -2,7 +2,15 @@ class RedisError(Exception):
     pass
 
 
-class AuthenticationError(RedisError):
+class AuthenticationFailureError(RedisError):
+    pass
+
+
+class AuthenticationRequiredError(RedisError):
+    pass
+
+
+class NoPermissionError(RedisError):
     pass
 
 

--- a/aredis/pipeline.py
+++ b/aredis/pipeline.py
@@ -103,7 +103,7 @@ class BasePipeline:
         conn = self.connection
         # if this is the first call, we need a connection
         if not conn:
-            conn = self.connection_pool.get_connection()
+            conn = await self.connection_pool.get_connection()
             self.connection = conn
         try:
             await conn.send_command(*args)
@@ -277,7 +277,7 @@ class BasePipeline:
 
         conn = self.connection
         if not conn:
-            conn = self.connection_pool.get_connection()
+            conn = await self.connection_pool.get_connection()
             # assign to self.connection so reset() releases the connection
             # back to the pool after we're done
             self.connection = conn

--- a/aredis/pipeline.py
+++ b/aredis/pipeline.py
@@ -46,7 +46,7 @@ class BasePipeline:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        await self.reset()
+        await self.execute()
 
     def __len__(self):
         return len(self.command_stack)

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -422,8 +422,8 @@ class ClusterConnectionPool(ConnectionPool):
         # discard connection with unread response
         if connection.awaiting_response:
             connection.disconnect()
-            # reduce node connection count in case of too many connection error raised
-            if self.max_connections_per_node and self._created_connections_per_node.get(connection.node['name']):
+            # reduce node connection count in case of too many connections error raised
+            if self._created_connections_per_node.get(connection.node['name']):
                 self._created_connections_per_node[connection.node['name']] -= 1
         else:
             self._available_connections.setdefault(connection.node["name"], []).append(connection)

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -328,7 +328,10 @@ class ClusterConnectionPool(ConnectionPool):
                     and not connection.awaiting_response):
                 connection.disconnect()
                 node = connection.node
-                self._available_connections[node['name']].remove(connection)
+                try:
+                    self._available_connections[node['name']].remove(connection)
+                except ValueError:
+                    pass
                 self._created_connections_per_node[node['name']] -= 1
                 break
             await asyncio.sleep(self.idle_check_interval)

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -103,10 +103,12 @@ class ConnectionPool:
                     url_options[name] = value[0]
 
         if decode_components:
+            username = unquote(url.username) if url.username else None
             password = unquote(url.password) if url.password else None
             path = unquote(url.path) if url.path else None
             hostname = unquote(url.hostname) if url.hostname else None
         else:
+            username = url.username
             password = url.password
             path = url.path
             hostname = url.hostname
@@ -114,6 +116,7 @@ class ConnectionPool:
         # We only support redis:// and unix:// schemes.
         if url.scheme == 'unix':
             url_options.update({
+                'username': username,
                 'password': password,
                 'path': path,
                 'connection_class': UnixDomainSocketConnection,
@@ -123,6 +126,7 @@ class ConnectionPool:
             url_options.update({
                 'host': hostname,
                 'port': int(url.port or 6379),
+                'username': username,
                 'password': password,
             })
 

--- a/aredis/pool.py
+++ b/aredis/pool.py
@@ -214,20 +214,20 @@ class ConnectionPool:
                 self.disconnect()
                 self.reset()
 
-    def get_connection(self, *args, **kwargs):
+    async def get_connection(self, *args, **kwargs):
         """Gets a connection from the pool"""
         self._checkpid()
         try:
             connection = self._available_connections.pop()
         except IndexError:
+            if self._created_connections >= self.max_connections:
+                raise ConnectionError("Too many connections")
             connection = self.make_connection()
         self._in_use_connections.add(connection)
         return connection
 
     def make_connection(self):
         """Creates a new connection"""
-        if self._created_connections >= self.max_connections:
-            raise ConnectionError("Too many connections")
         self._created_connections += 1
         connection = self.connection_class(**self.connection_kwargs)
         if self.max_idle_time > self.idle_check_interval > 0:
@@ -255,6 +255,132 @@ class ConnectionPool:
         for connection in all_conns:
             connection.disconnect()
             self._created_connections -= 1
+
+
+class BlockingConnectionPool(ConnectionPool):
+    """
+    Blocking connection pool::
+
+        >>> from aredis import StrictRedis
+        >>> client = StrictRedis(connection_pool=BlockingConnectionPool())
+
+    It performs the same function as the default
+    :py:class:`~aredis.ConnectionPool` implementation, in that,
+    it maintains a pool of reusable connections that can be shared by
+    multiple redis clients.
+
+    The difference is that, in the event that a client tries to get a
+    connection from the pool when all of connections are in use, rather than
+    raising a :py:class:`~aredis.ConnectionError` (as the default
+    :py:class:`~aredis.ConnectionPool` implementation does), it
+    makes the client wait ("blocks") for a specified number of seconds until
+    a connection becomes available.
+
+    Use ``max_connections`` to increase / decrease the pool size::
+
+        >>> pool = BlockingConnectionPool(max_connections=10)
+
+    Use ``timeout`` to tell it either how many seconds to wait for a connection
+    to become available, or to block forever:
+
+        >>> # Block forever.
+        >>> pool = BlockingConnectionPool(timeout=None)
+
+        >>> # Raise a ``ConnectionError`` after five seconds if a connection is
+        >>> # not available.
+        >>> pool = BlockingConnectionPool(timeout=5)
+    """
+    def __init__(self, connection_class=Connection, queue_class=asyncio.LifoQueue,
+                 max_connections=None, timeout=20, max_idle_time=0, idle_check_interval=1,
+                 **connection_kwargs):
+
+        self.timeout = timeout
+        self.queue_class = queue_class
+
+        max_connections = max_connections or 50
+
+        super(BlockingConnectionPool, self).__init__(
+            connection_class=connection_class, max_connections=max_connections,
+            max_idle_time=max_idle_time, idle_check_interval=idle_check_interval,
+            **connection_kwargs)
+
+    async def disconnect_on_idle_time_exceeded(self, connection):
+        while True:
+            if (time.time() - connection.last_active_at > self.max_idle_time
+                    and not connection.awaiting_response):
+                # Unlike the non blocking pool, we don't free the connection object,
+                # but always reuse it
+                connection.disconnect()
+                break
+            await asyncio.sleep(self.idle_check_interval)
+
+    def reset(self):
+        self._pool = self.queue_class(self.max_connections)
+        while True:
+            try:
+                self._pool.put_nowait(None)
+            except asyncio.QueueFull:
+                break
+
+        super(BlockingConnectionPool, self).reset()
+
+    async def get_connection(self, *args, **kwargs):
+        """Gets a connection from the pool"""
+        self._checkpid()
+
+        connection = None
+
+        try:
+            connection = await asyncio.wait_for(
+                self._pool.get(),
+                self.timeout
+            )
+        except asyncio.TimeoutError:
+            raise ConnectionError("No connection available.")
+
+        if connection is None:
+            connection = self.make_connection()
+
+        self._in_use_connections.add(connection)
+        return connection
+
+    def release(self, connection):
+        """Releases the connection back to the pool"""
+        self._checkpid()
+        if connection.pid != self.pid:
+            return
+        self._in_use_connections.remove(connection)
+        # discard connection with unread response
+        if connection.awaiting_response:
+            connection.disconnect()
+            connection = None
+
+        try:
+            self._pool.put_nowait(connection)
+        except asyncio.QueueFull:
+            # perhaps the pool have been reset() ?
+            pass
+
+    def disconnect(self):
+        """Closes all connections in the pool"""
+        pooled_connections = []
+        while True:
+            try:
+                pooled_connections.append(self._pool.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+
+        for conn in pooled_connections:
+            try:
+                self._pool.put_nowait(conn)
+            except asyncio.QueueFull:
+                pass
+
+        all_conns = chain(pooled_connections,
+                          self._in_use_connections)
+        for connection in all_conns:
+            if connection is not None:
+                connection.disconnect()
 
 
 class ClusterConnectionPool(ConnectionPool):
@@ -359,7 +485,7 @@ class ClusterConnectionPool(ConnectionPool):
                 self.disconnect()
                 self.reset()
 
-    def get_connection(self, command_name, *keys, **options):
+    async def get_connection(self, command_name, *keys, **options):
         # Only pubsub command/connection should be allowed here
         if command_name != "pubsub":
             raise RedisClusterException("Only 'pubsub' commands can use get_connection()")

--- a/aredis/pubsub.py
+++ b/aredis/pubsub.py
@@ -115,7 +115,7 @@ class PubSub:
                 # disconnect if buffer is not empty in case of error
                 # when connection is reused
                 connection.disconnect()
-            return None
+            raise
         except (ConnectionError, TimeoutError) as e:
             connection.disconnect()
             if not connection.retry_on_timeout and isinstance(e, TimeoutError):

--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -14,7 +14,8 @@ Pipelines are quite simple to use:
     async with await client.pipeline() as pipe:
         await pipe.delete('bar')
         await pipe.set('bar', 'foo')
-        await pipe.execute()  # needs to be called explicitly
+
+    # the pipeline is automatically executed when the `with` block exits
 
 
 Here are more examples:
@@ -30,6 +31,7 @@ Here are more examples:
             await pipe.set('bar', 'foo')
             # commands will be buffered
             await pipe.keys('*')
+            # we can call `pipe.execute()` explicitly to get the results
             res = await pipe.execute()
             # results should be in order corresponding to your command
             assert res == [True, True, True, [b'bar', b'foo']]
@@ -100,11 +102,11 @@ explicitly calling reset():
 
     async def example():
         async with await r.pipeline() as pipe:
-            while 1:
+            while True:
                 try:
                     await pipe.watch('OUR-SEQUENCE-KEY')
                     ...
-                    await pipe.execute()
+                    await pipe.execute()  # trigger any WatchError early
                     break
                 except WatchError:
                     continue

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -68,6 +68,12 @@ class TestRedisCommands:
 
     @skip_if_server_version_lt('2.6.9')
     @pytest.mark.asyncio(forbid_global_loop=True)
+    async def test_client_getname_from_init(self, event_loop):
+        r = aredis.StrictRedis(client_name='test', loop=event_loop)
+        assert await r.client_getname() == 'test'
+
+    @skip_if_server_version_lt('2.6.9')
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_client_setname(self, r):
         assert await r.client_setname('redis_py_test')
         assert await r.client_getname() == 'redis_py_test'

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -717,6 +717,17 @@ class TestRedisCommands:
         assert await r.set('a', '1', xx=True, px=10000)
         assert 0 < await r.ttl('a') <= 10
 
+    @skip_if_server_version_lt('6.0.0')
+    @pytest.mark.asyncio(forbid_global_loop=True)
+    async def test_set_keepttl(self, r):
+        await r.flushdb()
+        await r.set('a', 'val')
+        assert await r.set('a', '1', xx=True, px=10000)
+        assert 0 < await r.ttl('a') <= 10
+        await r.set('a', '2', keepttl=True)
+        assert await r.get('a') == b('2')
+        assert 0 < await r.ttl('a') <= 10
+
     @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_setex(self, r):
         await r.flushdb()

--- a/tests/client/test_connection_pool.py
+++ b/tests/client/test_connection_pool.py
@@ -95,6 +95,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -105,6 +106,7 @@ class TestConnectionPoolURLParsing:
             'host': 'myhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -116,6 +118,7 @@ class TestConnectionPoolURLParsing:
             'host': 'my / host +=+',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -126,7 +129,19 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6380,
             'db': 0,
+            'username': None,
             'password': None,
+        }
+
+    def test_username(self):
+        pool = aredis.ConnectionPool.from_url('redis://myusername:@localhost')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'username': 'myusername',
+            'password': '',
         }
 
     def test_password(self):
@@ -136,6 +151,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': '',
             'password': 'mypassword',
         }
 
@@ -148,7 +164,19 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': '/mypass/+ word=$+',
+        }
+
+    def test_username_and_password(self):
+        pool = aredis.ConnectionPool.from_url('redis://myusername:mypassword@localhost')
+        assert pool.connection_class == aredis.Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'username': 'myusername',
+            'password': 'mypassword',
         }
 
     def test_db_as_argument(self):
@@ -158,6 +186,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 1,
+            'username': None,
             'password': None,
         }
 
@@ -168,6 +197,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 2,
+            'username': None,
             'password': None,
         }
 
@@ -179,6 +209,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 3,
+            'username': None,
             'password': None,
         }
 
@@ -194,6 +225,7 @@ class TestConnectionPoolURLParsing:
             'db': 2,
             'stream_timeout': 20.0,
             'connect_timeout': 10.0,
+            'username': None,
             'password': None,
         }
 
@@ -232,6 +264,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
             'a': '1',
             'b': '2'
@@ -244,6 +277,7 @@ class TestConnectionPoolURLParsing:
             'host': 'myhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -255,7 +289,18 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 0,
+            'username': None,
             'password': None,
+        }
+
+    def test_username(self):
+        pool = aredis.ConnectionPool.from_url('unix://myusername:@/socket')
+        assert pool.connection_class == aredis.UnixDomainSocketConnection
+        assert pool.connection_kwargs == {
+            'path': '/socket',
+            'db': 0,
+            'username': 'myusername',
+            'password': '',
         }
 
     def test_password(self):
@@ -264,6 +309,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 0,
+            'username': '',
             'password': 'mypassword',
         }
 
@@ -275,7 +321,18 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 0,
+            'username': None,
             'password': '/mypass/+ word=$+',
+        }
+
+    def test_username_and_password(self):
+        pool = aredis.ConnectionPool.from_url('unix://myusername:mypassword@/socket')
+        assert pool.connection_class == aredis.UnixDomainSocketConnection
+        assert pool.connection_kwargs == {
+            'path': '/socket',
+            'db': 0,
+            'username': 'myusername',
+            'password': 'mypassword',
         }
 
     def test_quoted_path(self):
@@ -286,6 +343,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/my/path/to/../+_+=$ocket',
             'db': 0,
+            'username': None,
             'password': 'mypassword',
         }
 
@@ -295,6 +353,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 1,
+            'username': None,
             'password': None,
         }
 
@@ -304,6 +363,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 2,
+            'username': None,
             'password': None,
         }
 
@@ -313,6 +373,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 0,
+            'username': None,
             'password': None,
             'a': '1',
             'b': '2'
@@ -328,6 +389,7 @@ class TestSSLConnectionURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 

--- a/tests/client/test_pipeline.py
+++ b/tests/client/test_pipeline.py
@@ -49,6 +49,20 @@ class TestPipeline:
             assert not pipe
 
     @pytest.mark.asyncio(forbid_global_loop=True)
+    async def test_pipeline_autoexecute(self, r):
+        await r.flushdb()
+        async with await r.pipeline() as pipe:
+            # Fill 'er up!
+            await pipe.set('d', 'd1')
+            await pipe.set('e', 'e1')
+            await pipe.set('f', 'f1')
+            assert len(pipe) == 3
+            assert pipe
+
+        # exiting with block calls execute() and reset(), so empty once again
+        assert len(pipe) == 0
+
+    @pytest.mark.asyncio(forbid_global_loop=True)
     async def test_pipeline_no_transaction(self, r):
         await r.flushdb()
         async with await r.pipeline(transaction=False) as pipe:

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -264,6 +264,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -274,6 +275,7 @@ class TestConnectionPoolURLParsing:
             'host': 'myhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -285,6 +287,7 @@ class TestConnectionPoolURLParsing:
             'host': 'my / host +=+',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -295,7 +298,19 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6380,
             'db': 0,
+            'username': None,
             'password': None,
+        }
+
+    def test_username(self):
+        pool = ConnectionPool.from_url('redis://myusername:@localhost')
+        assert pool.connection_class == Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'username': 'myusername',
+            'password': '',
         }
 
     def test_password(self):
@@ -305,6 +320,18 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': '',
+            'password': 'mypassword',
+        }
+
+    def test_username_and_password(self):
+        pool = ConnectionPool.from_url('redis://myusername:mypassword@localhost')
+        assert pool.connection_class == Connection
+        assert pool.connection_kwargs == {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'username': 'myusername',
             'password': 'mypassword',
         }
 
@@ -317,6 +344,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': '/mypass/+ word=$+',
         }
 
@@ -328,6 +356,7 @@ class TestConnectionPoolURLParsing:
         assert pool.connection_kwargs == {
             'path': '/my/path/to/../+_+=$ocket',
             'db': 0,
+            'username': None,
             'password': 'mypassword',
         }
 
@@ -338,6 +367,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 1,
+            'username': None,
             'password': None,
         }
 
@@ -348,6 +378,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 2,
+            'username': None,
             'password': None,
         }
 
@@ -359,6 +390,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 3,
+            'username': None,
             'password': None,
         }
 
@@ -369,6 +401,7 @@ class TestConnectionPoolURLParsing:
             'host': 'localhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
             'a': '1',
             'b': '2'
@@ -381,6 +414,7 @@ class TestConnectionPoolURLParsing:
             'host': 'myhost',
             'port': 6379,
             'db': 0,
+            'username': None,
             'password': None,
         }
 
@@ -392,7 +426,18 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 0,
+            'username': None,
             'password': None,
+        }
+
+    def test_username(self):
+        pool = ConnectionPool.from_url('unix://myusername:@/socket')
+        assert pool.connection_class == UnixDomainSocketConnection
+        assert pool.connection_kwargs == {
+            'path': '/socket',
+            'db': 0,
+            'username': 'myusername',
+            'password': '',
         }
 
     def test_password(self):
@@ -401,6 +446,17 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 0,
+            'username': '',
+            'password': 'mypassword',
+        }
+
+    def test_username_and_password(self):
+        pool = ConnectionPool.from_url('unix://myusername:mypassword@/socket')
+        assert pool.connection_class == UnixDomainSocketConnection
+        assert pool.connection_kwargs == {
+            'path': '/socket',
+            'db': 0,
+            'username': 'myusername',
             'password': 'mypassword',
         }
 
@@ -410,6 +466,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 1,
+            'username': None,
             'password': None,
         }
 
@@ -419,6 +476,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 2,
+            'username': None,
             'password': None,
         }
 
@@ -428,6 +486,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_kwargs == {
             'path': '/socket',
             'db': 0,
+            'username': None,
             'password': None,
             'a': '1',
             'b': '2'

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -58,7 +58,7 @@ class TestConnectionPool:
         """
         pool = await self.get_pool()
         pool._in_use_connections = {}
-        pool.get_connection("pubsub", channel="foobar")
+        await pool.get_connection("pubsub", channel="foobar")
 
     @pytest.mark.asyncio()
     async def test_connection_creation(self):
@@ -173,7 +173,7 @@ class TestConnectionPool:
         pool = await self.get_pool()
 
         with pytest.raises(RedisClusterException) as ex:
-            pool.get_connection("GET")
+            await pool.get_connection("GET")
         assert str(ex.value).startswith("Only 'pubsub' commands can use get_connection()")
 
     @pytest.mark.asyncio()

--- a/tests/cluster/test_commands.py
+++ b/tests/cluster/test_commands.py
@@ -562,6 +562,17 @@ class TestRedisCommands:
         assert 0 < await r.ttl('a') <= 10
 
     @pytest.mark.asyncio
+    @skip_if_server_version_lt('6.0.0')
+    async def test_set_keepttl(self, r):
+        await r.flushdb()
+        await r.set('a', 'val')
+        assert await r.set('a', '1', xx=True, px=10000)
+        assert 0 < await r.ttl('a') <= 10
+        await r.set('a', '2', keepttl=True)
+        assert await r.get('a') == b('2')
+        assert 0 < await r.ttl('a') <= 10
+
+    @pytest.mark.asyncio
     async def test_setex(self, r):
         await r.flushdb()
         assert await r.setex('a', 60, '1')

--- a/tests/cluster/test_commands.py
+++ b/tests/cluster/test_commands.py
@@ -385,9 +385,26 @@ class TestRedisCommands:
         assert await r.mget('a', 'other', 'b', 'c') == [b('1'), None, b('2'), b('3')]
 
     @pytest.mark.asyncio
+    async def test_mget_hash_tags(self, r):
+        await r.flushdb()
+        assert await r.mget(['a{foo}', 'b{foo}']) == [None, None]
+        await r.set('a{foo}', 1)
+        await r.set('b{foo}', 2)
+        await r.set('c{bar}', 3)
+        assert await r.mget('a{foo}', 'other', 'b{foo}', 'c{bar}') == [b('1'), None, b('2'), b('3')]
+
+    @pytest.mark.asyncio
     async def test_mset(self, r):
         await r.flushdb()
         d = {'a': b('1'), 'b': b('2'), 'c': b('3')}
+        assert await r.mset(d)
+        for k, v in iteritems(d):
+            assert await r.mget(k) == [v]
+
+    @pytest.mark.asyncio
+    async def test_mset_hash_tags(self, r):
+        await r.flushdb()
+        d = {'a{foo}': b('1'), 'b{foo}': b('2'), 'c{bar}': b('3')}
         assert await r.mset(d)
         for k, v in iteritems(d):
             assert await r.mget(k) == [v]


### PR DESCRIPTION
I went through the list of all open aredis PRs (as of yesterday, looks like there's a couple more today which might be worth grabbing), modified 'em all to cleanly apply on top of each other and fix an couple oversights, and tossed them here. This branch is best viewed commit-by-commit, as such!

Once this is merged in, I think that marks a good place to cut this fork; at that point, we can start making more significant changes without missing out on pending improvements from the community.

The HEAD of this branch has been tested with `realtime-registration` locally and seems to be working pretty well, but we'll want much more thorough testing before marking a v2.0.0 release (and potentially more changes as well, especially looking into some of the lingering issues we've been seeing as alerts).

Full changelog:

```
60205b7 (Eoghan Murray)
    feat(scan): add TYPE option

    Note than SCAN ... [TYPE] is only available in Redis v6.0+

53f554a (Mehdi Abaakouk, 68 minutes ago)
   feat(pool): implement blocking connection pool

   Add new BlockingConnectionPool, which can be dropped in in-place of the 
   default connection pool. When using the new pool, rather than raising an 
   exception if we attempt to make too many connections, the given command is
   queued up to some timeout value instead.

   Note that the BlockingConnectionPool is currently only supported for the 
   redis client rather than the cluster client.

   Breaking change: `ConnectionPool.get_connection()` is now awaitable.

   Note as well that the Pubsub client now fetches the connection's encoding
   lazily prior to its first usage rather than on init.

   Co-authored-by: Kevin James <kevinjames@thekev.in>

7f456d7 (Dov Reshef, 3 months ago)
   feat(auth): add support for Redis 5+ user+pass auth

   When `Client()` receives both a username and a password, send both in the
   AUTH command.

   Co-authored-by: Kevin James <kevinjames@thekev.in>

73433f3 (Eoghan Murray, 6 months ago)
   perf(cluster): support MGET and MSET for hashed keys

   Detect use of keys with hash tags (which guarantee they hash to the same 
   redis node) and use MGET/MSET for the full groups of keys rather than 
   running individual GET/SET commands on each key in series.

   See https://redis.io/topics/cluster-tutorial#redis-cluster-data-sharding 
   for more info on key hash tags.

   Co-authored-by: Kevin James <kevinjames@thekev.in>

b12b9b2 (Eoghan Murray, 35 hours ago)
   fix(connection): always reduce count on force disconnect

   Fixes a connection count leak in cases where `max_connections_per_node` is
   set to False.

   Currently, forced disconnects are not counted when
   `max_connections_per_node` is unset, leading to behaviour where aredis 
   thinks there are more active connections than there really are, which may
   in turn lead to MaxConnection errors being raised unnecessarily.

9fa2882 (Chaerim Yeo, 5 weeks ago)
   fix(cluster): avoid runtime error on disconnected client

   Ensures we do not raise a runtime error in race conditions where a 
   disconnected client also fails an idle check before state can be synced.

b3b8d5d (Mehdi Abaakouk, 2 months ago)
   fix(connection): expose initial connect() error message

   No functional change, but any errors on the initial `connect()` operation
   now have their `exc.args` included in the raised ConnectionError.

   Co-authored-by: Kevin James <kevinjames@thekev.in>

41fd6ba (Sam Mosleh, 5 months ago)
   fix(pubsub): reraise CancelledError during _execute

   Ensures we continue CancelledError propogation if it occurs while we're 
   executing a pubsub command.

6d29d5b (Sam Mosleh, 7 months ago)
   feat(commands): add support for SET's KEEPTTL option

   Note that this command is v6.0.0+, which has not yet been fully tested with
   aredis. v6.x functionality is currently presented without guarantees.

7f1a9fa (lyncir, 7 months ago)
   fix(client): prevent retry_on_timeout from affecting ConnectionError

   Setting `connection.retry_on_timeout` now only applies to TimeoutError 
   rather than to ConnectionError as well.

   Co-authored-by: Kevin James <kevinjames@thekev.in>

ee439c8 (Eoghan Murray, 9 months ago)
   feat(pipeline): auto-execute all commands at end of with

   This is a breaking change wherein exiting the scope of the `with 
   pipeline()` block will automatically execute all pending commands.

   For example:

       async with await r.pipeline() as pipe:
           await pipe.delete('foo')

   Note that `await pipe.execute()` can still be called within the pipeline in
   cases where you want to retrieve the results early, run multiple sets of
   commands in the same pipeline, or force exceptions to be raised early.

   For example:

       async with await r.pipeline() as pipe:
           await pipe.delete('foo')
           res = await pipe.execute()

       if res[0] == 1:  # a key was deleted in the previous setp
           await pipe.incr('deleted-keys')
           res = await pipe.execute()
           print(f"I've deleted {res[0]} keys so far!")

   Co-authored-by: Kevin James <kevinjames@thekev.in>

08119ce (Dov Reshef, 10 months ago)
   feat(client): add option to init with client name

   Allows the `client_name: Optional[str]` argument to be passed into a new 
   client, which will be set via `CLIENT SETNAME` for each new connection.

   Co-authored-by: Kevin James <kevinjames@thekev.in>
```