### PR TITLE
SCAN: Iterate over cluster nodes in parallel rather than sequentially

### DIFF
--- a/yaaredis/commands/iter.py
+++ b/yaaredis/commands/iter.py
@@ -86,7 +86,6 @@ class ClusterIterCommandMixin(IterCommandMixin):
         nodes = await self.cluster_nodes()
 
         async def iterate_node(node, queue):
-            nonlocal match, count, type, nodes
             cursor = '0'
             while cursor != 0:
                 pieces = [cursor]

--- a/yaaredis/commands/iter.py
+++ b/yaaredis/commands/iter.py
@@ -111,5 +111,5 @@ class ClusterIterCommandMixin(IterCommandMixin):
                 t = asyncio.create_task(iterate_node(node, queue))
                 tasks.append(t)
 
-        while not all(t.done() for t in tasks):
+        while not all(t.done() for t in tasks) or not queue.empty():
             yield await queue.get()

--- a/yaaredis/commands/iter.py
+++ b/yaaredis/commands/iter.py
@@ -103,7 +103,12 @@ class ClusterIterCommandMixin(IterCommandMixin):
 
         # maxsize ensures we don't pull too much data into
         # memory if we are not processing it yet
-        queue = asyncio.Queue(maxsize=1000)
+        maxsize = 10 if count is None else count
+        # reducing maxsize by one: the idea here is that the SCAN for an individual
+        # node can never fill the queue in a single iteration, so we'll get at most
+        # one SCAN iteration for each node if the queue is never consumed
+        maxsize -= 1
+        queue = asyncio.Queue(maxsize=maxsize)
         tasks = []
         for node in nodes:
             if 'master' in node['flags']:


### PR DESCRIPTION
 - with a MATCH scan I measured this as iterating over 2.5x keys per second compared to previous version (with 8 cluster nodes)