### PR TITLE
fix(clusterdown_wrapper): fix broken retry logic

### DIFF
--- a/tests/client/cache_test.py
+++ b/tests/client/cache_test.py
@@ -42,7 +42,7 @@ async def test_set_timeout(r, event_loop):
     content = cache._unpack(content)
     assert content == DATA
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(1.1)
     content = await r.get(identity)
     assert content is None
 

--- a/tests/cluster/node_manager_test.py
+++ b/tests/cluster/node_manager_test.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from tests.cluster.conftest import skip_if_server_version_lt
+from yaaredis import ClusterUnreachableError
 from yaaredis import ConnectionError  # pylint: disable=redefined-builtin
 from yaaredis import RedisClusterException
 from yaaredis import StrictRedis
@@ -392,6 +393,6 @@ async def test_init_with_down_node():
 
     with patch.object(NodeManager, 'get_redis_link', side_effect=get_redis_link):
         n = NodeManager(startup_nodes=[{'host': '127.0.0.1', 'port': 7000}])
-        with pytest.raises(RedisClusterException) as e:
+        with pytest.raises(ClusterUnreachableError) as e:
             await n.initialize()
         assert 'Redis Cluster cannot be connected' in str(e.value)

--- a/yaaredis/__init__.py
+++ b/yaaredis/__init__.py
@@ -14,6 +14,7 @@ from .exceptions import ClusterCrossSlotError
 from .exceptions import ClusterDownError
 from .exceptions import ClusterDownException
 from .exceptions import ClusterError
+from .exceptions import ClusterUnreachableError
 from .exceptions import CompressError
 from .exceptions import ConnectionError  # pylint: disable=redefined-builtin
 from .exceptions import DataError
@@ -42,9 +43,9 @@ __all__ = [
     'AuthenticationFailureError', 'AuthenticationRequiredError',
     'BusyLoadingError', 'CacheError', 'ClusterCrossSlotError',
     'ClusterDownError', 'ClusterDownException', 'ClusterError',
-    'CompressError', 'ConnectionError', 'DataError', 'ExecAbortError',
-    'InvalidResponse', 'LockError', 'NoPermissionError', 'NoScriptError',
-    'PubSubError', 'ReadOnlyError', 'RedisClusterError',
+    'ClusterUnreachableError', 'CompressError', 'ConnectionError', 'DataError',
+    'ExecAbortError', 'InvalidResponse', 'LockError', 'NoPermissionError',
+    'NoScriptError', 'PubSubError', 'ReadOnlyError', 'RedisClusterError',
     'RedisClusterException', 'RedisError', 'ResponseError', 'TimeoutError',
     'WatchError',
 ]

--- a/yaaredis/client.py
+++ b/yaaredis/client.py
@@ -37,8 +37,8 @@ from .connection import UnixDomainSocketConnection
 from .exceptions import AskError
 from .exceptions import BusyLoadingError
 from .exceptions import ClusterDownError
-from .exceptions import ClusterUnreachableError
 from .exceptions import ClusterError
+from .exceptions import ClusterUnreachableError
 from .exceptions import ConnectionError  # pylint: disable=redefined-builtin
 from .exceptions import MovedError
 from .exceptions import RedisClusterException

--- a/yaaredis/client.py
+++ b/yaaredis/client.py
@@ -37,6 +37,7 @@ from .connection import UnixDomainSocketConnection
 from .exceptions import AskError
 from .exceptions import BusyLoadingError
 from .exceptions import ClusterDownError
+from .exceptions import ClusterUnreachableError
 from .exceptions import ClusterError
 from .exceptions import ConnectionError  # pylint: disable=redefined-builtin
 from .exceptions import MovedError

--- a/yaaredis/client.py
+++ b/yaaredis/client.py
@@ -295,7 +295,8 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
         super().__init__(
             connection_pool=pool, **kwargs)
 
-        self.refresh_table_asap = False
+        self.moved = False
+        self.cluster_down = False
         self.nodes_flags = self.__class__.NODES_FLAGS.copy()
         self.result_callbacks = self.__class__.RESULT_CALLBACKS.copy()
         self.response_callbacks = self.__class__.RESPONSE_CALLBACKS.copy()
@@ -419,10 +420,16 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
         if node:
             return await self.execute_command_on_nodes(node, *args, **kwargs)
 
-        # If set externally we must update it before calling any commands
-        if self.refresh_table_asap:
-            await self.connection_pool.nodes.initialize()
-            self.refresh_table_asap = False
+        # rebuild slot->node mapping after a MovedError or ClusterDownError
+        if self.moved or self.cluster_down:
+            try:
+                await self.connection_pool.nodes.initialize()
+            except ClusterUnreachableError:
+                if self.moved:
+                    raise
+                # implicitly pass if cluster_down and cluster not reachable
+            self.cluster_down = False
+            self.moved = False
 
         redirect_addr = None
         asking = False
@@ -441,7 +448,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
                 r = self.connection_pool.get_random_connection()
                 try_random_node = False
             else:
-                if self.refresh_table_asap:
+                if self.moved:
                     # MOVED
                     node = self.connection_pool.get_master_node_by_slot(slot)
                 else:
@@ -466,7 +473,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
             except ClusterDownError as e:
                 self.connection_pool.disconnect()
                 self.connection_pool.reset()
-                self.refresh_table_asap = True
+                self.cluster_down = True
 
                 raise e
             except MovedError as e:
@@ -474,7 +481,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
                 # This counter will increase faster when the same client object
                 # is shared between multiple threads. To reduce the frequency you
                 # can set the variable 'reinitialize_steps' in the constructor.
-                self.refresh_table_asap = True
+                self.moved = True
                 await self.connection_pool.nodes.increment_reinitialize_counter()
 
                 node = self.connection_pool.nodes.set_node(

--- a/yaaredis/exceptions.py
+++ b/yaaredis/exceptions.py
@@ -84,6 +84,10 @@ class RedisClusterError(Exception):
     pass
 
 
+class ClusterUnreachableError(Exception):
+    pass
+
+
 class ClusterDownException(Exception):
     pass
 

--- a/yaaredis/nodemanager.py
+++ b/yaaredis/nodemanager.py
@@ -1,7 +1,7 @@
 import random
 
-from .exceptions import ConnectionError  # pylint: disable=redefined-builtin
 from .exceptions import ClusterUnreachableError
+from .exceptions import ConnectionError  # pylint: disable=redefined-builtin
 from .exceptions import RedisClusterException
 from .utils import b
 from .utils import hash_slot

--- a/yaaredis/nodemanager.py
+++ b/yaaredis/nodemanager.py
@@ -1,6 +1,7 @@
 import random
 
 from .exceptions import ConnectionError  # pylint: disable=redefined-builtin
+from .exceptions import ClusterUnreachableError
 from .exceptions import RedisClusterException
 from .utils import b
 from .utils import hash_slot
@@ -31,7 +32,6 @@ class NodeManager:
         self.reinitialize_steps = reinitialize_steps or 25
         self._skip_full_coverage_check = skip_full_coverage_check
         self.nodemanager_follow_cluster = nodemanager_follow_cluster
-        self.refresh_table_asap = False
 
         if not self.startup_nodes:
             raise RedisClusterException('No startup nodes provided')
@@ -178,7 +178,6 @@ class NodeManager:
                                                             .format(', '.join(disagreements)))
 
                 self.populate_startup_nodes()
-                self.refresh_table_asap = False
 
             if self._skip_full_coverage_check:
                 need_full_slots_coverage = False
@@ -195,8 +194,8 @@ class NodeManager:
                 break
 
         if not startup_nodes_reachable:
-            raise RedisClusterException('Redis Cluster cannot be connected. '
-                                        'Please provide at least one reachable node.')
+            raise ClusterUnreachableError('Redis Cluster cannot be connected. '
+                                          'Please provide at least one reachable node.')
 
         if not all_slots_covered:
             raise RedisClusterException('Not all slots are covered after query all startup_nodes. '

--- a/yaaredis/pipeline.py
+++ b/yaaredis/pipeline.py
@@ -343,7 +343,6 @@ class StrictClusterPipeline(StrictRedisCluster):
                  transaction=False, watches=None):
         # pylint: disable=super-init-not-called
         self.command_stack = []
-        self.refresh_table_asap = False
         self.connection_pool = connection_pool
         self.result_callbacks = result_callbacks or self.__class__.RESULT_CALLBACKS.copy()
         self.startup_nodes = startup_nodes if startup_nodes else []
@@ -354,6 +353,8 @@ class StrictClusterPipeline(StrictRedisCluster):
         self.watches = watches or None
         self.watching = False
         self.explicit_transaction = False
+        self.moved = False
+        self.cluster_down = False
 
     def __repr__(self):
         return '{}'.format(type(self).__name__)

--- a/yaaredis/utils.py
+++ b/yaaredis/utils.py
@@ -2,6 +2,7 @@ import sys
 from functools import wraps
 
 from .exceptions import ClusterDownError
+from .exceptions import ClusterUnreachableError
 from .exceptions import RedisClusterException
 
 
@@ -165,10 +166,13 @@ def clusterdown_wrapper(func):
 
     If the cluster reports it is down it is assumed that:
      - connection_pool was disconnected
-     - connection_pool was reseted
-     - refereh_table_asap set to True
+     - connection_pool was reset
+     - refresh_table_asap set to True
 
-    It will try 3 times to rerun the command and raises ClusterDownException if it continues to fail.
+    If the cluster is still unreachable on a retry it will return a
+    ClusterUnreachableError which we also catch.
+
+    It will try 3 times to rerun the command and raises ClusterUnreachableError if it continues to fail.
     """
 
     @wraps(func)
@@ -176,14 +180,14 @@ def clusterdown_wrapper(func):
         for _ in range(0, 3):
             try:
                 return await func(*args, **kwargs)
-            except ClusterDownError:
+            except (ClusterDownError, ClusterUnreachableError):
                 # Try again with the new cluster setup. All other errors
                 # should be raised.
                 pass
 
         # If it fails 3 times then raise exception back to caller
-        raise ClusterDownError(
-            'CLUSTERDOWN error. Unable to rebuild the cluster')
+        raise ClusterUnreachableError(
+            'Cluster is down or unreachable. Unable to reconnect after 3 tries.')
 
     return inner
 


### PR DESCRIPTION
There may be a better solution than what I've added here, we might want to consider instead using `backoff`
This solution should put the code in line with what it's trying to do (which might still be wrong)

### The Problem:

We're been seeing a bunch of **RedisClusterException**: _Redis Cluster cannot be connected. Please provide at least one reachable node_ errors.  Following the stack trace I was able to isolate what was happening here.  

For whatever reason Redis sometimes sends us a `CLUSTERDOWN` response when we are trying to execute a command (using the `execute_command` function).  The `execute_command` function has a wrapper that will retry up to 3 times on a `ClusterDownError`.  However `execute_command` catches this error and sets `self.refresh_table_asap = True` before raising it to the wrapper.

This means the second time `execute_command` tries to send the command it hits a `if self.refresh_table_asap:` block that forces it to rebuild the `node_manager`, and when the `node_manager` fails to connect to any node in the cluster it raises a `RedisClusterException`, which bypasses the wrapper and returns control back to the calling program.  

### The Solution:

The solution I'm presenting in this PR is to create a new Exception class `ClusterUnreachableError` for cases where we can't connect to the cluster, and have that return instead of a `RedisClusterException`.  I am also splitting `refresh_table_asap` into `moved` and `cluster_down` so it's clearer why we need to rebuild the `node_manager` mapping.  In the case where the cause is `cluster_down` we can pass on a `ClusterUnreachableError`, to allow the `@clusterdown_wrapper` to do it's work.

This doesn't fix the error necessarily, but it will ensure that the correct error is being thrown, and that we actually retry first.

I'm not entirely sure this will fix the root cause, it may be a good idea to replace this custom wrapper with `backoff`, to give the cluster or the network time to get back into a functional state.


Anyways, that's all.  Happy to reimplement with a combination of these solutions, or additional ideas that pop up.