### PR TITLE
fix(cluster): fixup Cluster scan_iter bugs

### DIFF
--- a/tests/cluster/conftest.py
+++ b/tests/cluster/conftest.py
@@ -70,6 +70,12 @@ def skip_if_redis_py_version_lt(min_version):
     return pytest.mark.skipif(False, reason='')
 
 
+def skip_python_version_lt(min_version):
+    min_version = tuple(map(int, min_version.split('.')))
+    check = sys.version_info[:2] < min_version
+    return pytest.mark.skipif(check, reason='')
+
+
 @pytest.fixture(scope='function')
 def o(**kwargs):
     """


### PR DESCRIPTION
Fixes a few bugs introduced in v2.0.x:

* (from 2.0.0): the `type` param to `Cluster.scan_iter()` was set to
  a default value of `type` rather than `None`, causing
  `ResponseError: syntax error` to be thrown on calls with
  unspecified `type` values.

* (from 2.0.1): the `asyncio.create_task()` method was used rather than
  `asyncio.ensure_future()`, which broke support for Python 3.6.

* (from 2.0.1): `Cluster.scan_iter()` had a potential race condition
  caused by cases where the last node to return data had a final page in
  its SCAN which returned no matching data -- in that case, the thread
  would hang indefinitely.