### PR TITLE
fix(connection): avoid hiding timeout errors on connect

### DIFF
--- a/yaaredis/connection.py
+++ b/yaaredis/connection.py
@@ -432,7 +432,7 @@ class BaseConnection:
     async def connect(self):
         try:
             await self._connect()
-        except yaaredis.compat.CancelledError:
+        except (TimeoutError, yaaredis.compat.CancelledError):
             raise
         except Exception as e:
             raise ConnectionError('Error during initial connection') from e


### PR DESCRIPTION
Avoid overwriting any `TimeoutError`s caused by the `connect()` method
with a more general `Exception` type. This allows any future handlers --
such as the `retry_on_timeout` flag -- to work as expected during the
connection flow.