### PR TITLE
chore(compat): build&test for python3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ workflows:
             alias: pytest-client
             parameters:
               hiredis: [false, true]
-              python_version: ['3.5', '3.6', '3.7', '3.8']
+              python_version: ['3.5', '3.6', '3.7', '3.8', '3.9']
               redis_version: ['3', '4', '5', '6']
           filters:
             tags:
@@ -112,7 +112,7 @@ workflows:
             alias: pytest-cluster
             parameters:
               hiredis: [false, true]
-              python_version: ['3.5', '3.6', '3.7', '3.8']
+              python_version: ['3.5', '3.6', '3.7', '3.8', '3.9']
               # TODO: pin to latest builds
               redis_version: ['3.2.13', '4.0.14', '5.0.5', '6.0.12']
           filters:
@@ -122,7 +122,7 @@ workflows:
       - build:
           name: build-sdist
           format: sdist
-          python_version: '3.8'
+          python_version: '3.9'
           filters:
             branches:
               ignore: /.*/
@@ -138,7 +138,7 @@ workflows:
           matrix:
             alias: build-wheel
             parameters:
-              python_version: ['3.5', '3.6', '3.7', '3.8']
+              python_version: ['3.5', '3.6', '3.7', '3.8', '3.9']
           filters:
             branches:
               ignore: /.*/
@@ -150,7 +150,7 @@ workflows:
             - pytest-cluster
       - publish:
           context: org-global
-          python_version: '3.8'
+          python_version: '3.9'
           filters:
             branches:
               ignore: /.*/

--- a/.github/RELEASE.rst
+++ b/.github/RELEASE.rst
@@ -23,3 +23,12 @@ on OSX), you can provide bonus wheels with:
     $ rm -rf dist/
     $ poetry build -fwheel
     $ poetry publish
+
+If you're feeling even more generous, you can build for multiple Python
+versions with the following (TODO: do this via poetry):
+
+.. code-block:: console
+
+    $ rm -rf dist/
+    $ for version in 3.6 3.7 3.8 3.9; do poetry env use $version; poetry run pip wheel yaaredis -w dist/; done
+    $ poetry publish


### PR DESCRIPTION
Start testing and releasing optimized builds for Python3.9. It was already supported just fine as of at least 2.x, so no need for changes outside the build system.