### PR TITLE
add BlockingClusterConnectionPool

### DIFF
--- a/tests/cluster/readonly_connection_pool_test.py
+++ b/tests/cluster/readonly_connection_pool_test.py
@@ -34,10 +34,10 @@ async def test_repr_contains_db_info_readonly():
 @pytest.mark.asyncio()
 async def test_max_connections():
     pool = await get_pool(max_connections=2)
-    pool.get_connection_by_node({'host': '127.0.0.1', 'port': 7000})
-    pool.get_connection_by_node({'host': '127.0.0.1', 'port': 7001})
+    await pool.get_connection_by_node({'host': '127.0.0.1', 'port': 7000})
+    await pool.get_connection_by_node({'host': '127.0.0.1', 'port': 7001})
     with pytest.raises(RedisClusterException):
-        pool.get_connection_by_node({'host': '127.0.0.1', 'port': 7000})
+        await pool.get_connection_by_node({'host': '127.0.0.1', 'port': 7000})
 
 
 @pytest.mark.asyncio()

--- a/yaaredis/client.py
+++ b/yaaredis/client.py
@@ -443,9 +443,9 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
 
             if asking:
                 node = self.connection_pool.nodes.nodes[redirect_addr]
-                r = self.connection_pool.get_connection_by_node(node)
+                r = await self.connection_pool.get_connection_by_node(node)
             elif try_random_node:
-                r = self.connection_pool.get_random_connection()
+                r = await self.connection_pool.get_random_connection()
                 try_random_node = False
             else:
                 if self.moved:
@@ -453,7 +453,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
                     node = self.connection_pool.get_master_node_by_slot(slot)
                 else:
                     node = self.connection_pool.get_node_by_slot(slot)
-                r = self.connection_pool.get_connection_by_node(node)
+                r = await self.connection_pool.get_connection_by_node(node)
 
             try:
                 if asking:
@@ -502,7 +502,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
         res = {}
 
         for node in nodes:
-            connection = self.connection_pool.get_connection_by_node(node)
+            connection = await self.connection_pool.get_connection_by_node(node)
 
             # copy from redis-py
             try:

--- a/yaaredis/pipeline.py
+++ b/yaaredis/pipeline.py
@@ -461,7 +461,7 @@ class StrictClusterPipeline(StrictRedisCluster):
                     raise ClusterTransactionError(
                         "Keys in request don't hash to the same node")
             node = hashed_node
-        conn = self.connection_pool.get_connection_by_node(node)
+        conn = await self.connection_pool.get_connection_by_node(node)
         if self.watches:
             await self._watch(node, conn, self.watches)
         node_commands = NodeCommands(
@@ -521,7 +521,7 @@ class StrictClusterPipeline(StrictRedisCluster):
             node_name = node['name']
             if node_name not in nodes:
                 nodes[node_name] = NodeCommands(
-                    self.parse_response, self.connection_pool.get_connection_by_node(node))
+                    self.parse_response, await self.connection_pool.get_connection_by_node(node))
 
             nodes[node_name].append(c)
 


### PR DESCRIPTION
It doesn't support all the features that the non-cluster version provides, but at least this way I'm more confident in the distributed systems side working as expected. In particular note:

```
        assert max_idle_time == 0, "Max idle time not support for blocking version"
        assert max_connections_per_node, "Only per node connection limit is supported"
```