### PR TITLE
chore(lint): enable mccabe complexity plugin with default settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,9 @@ repos:
         - git+https://github.com/bayesimpact/pylint_import_modules@016f79e4d2
         args:
         - --allowed-direct-imports="typing.*"
-        - --load-plugins=pylint_import_modules
+        - --load-plugins=pylint_import_modules,pylint.extensions.mccabe
         # - --max-line-length=79  # TODO: enable me
+        - --max-complexity=10
         - --max-line-length=179
         - --max-args=10
         - --score=n
@@ -116,6 +117,7 @@ repos:
         - flake8-commas==2.1.0
         - flake8-comprehensions==3.10.0
         - flake8-typing-imports==1.12.0
+        - importlib-metadata<5
         args:
         # TODO: C406 should be ignored inline, but yesqa keeps stripping it out
         - --ignore=A001,A002,A003,C406,E501,W503,F401,F811

--- a/yaaredis/client.py
+++ b/yaaredis/client.py
@@ -411,7 +411,7 @@ class StrictRedisCluster(StrictRedis, *cluster_mixins):
         """
         Sends a command to a node in the cluster
         """
-        # pylint: disable=too-many-branches,too-many-statements
+        # pylint: disable=too-many-branches,too-many-statements,too-complex
         if not self.connection_pool.initialized:
             await self.connection_pool.initialize()
         if not args:

--- a/yaaredis/commands/geo.py
+++ b/yaaredis/commands/geo.py
@@ -145,6 +145,7 @@ class GeoCommandMixin:
                                             store_dist=store_dist)
 
     async def _georadiusgeneric(self, command, *args, **kwargs):
+        # pylint: disable=too-complex
         pieces = list(args)
         if kwargs['unit'] and kwargs['unit'] not in ('m', 'km', 'mi', 'ft'):
             raise RedisError('GEORADIUS invalid unit')

--- a/yaaredis/commands/iter.py
+++ b/yaaredis/commands/iter.py
@@ -83,6 +83,7 @@ class IterCommandMixin:
 class ClusterIterCommandMixin(IterCommandMixin):
     async def scan_iter(self, match=None, count=None,
                         type=None):  # pylint: disable=redefined-builtin
+        # pylint: disable=too-complex
         nodes = await self.cluster_nodes()
 
         async def iterate_node(node, queue):

--- a/yaaredis/commands/keys.py
+++ b/yaaredis/commands/keys.py
@@ -182,6 +182,7 @@ class KeysCommandMixin:
             values fetched from the arguments to ``get``.
 
         """
+        # pylint: disable=too-complex
         if ((start is not None and num is None)
                 or (num is not None and start is None)):
             raise RedisError('``start`` and ``num`` must both be specified')

--- a/yaaredis/commands/lists.py
+++ b/yaaredis/commands/lists.py
@@ -247,7 +247,7 @@ class ClusterListsCommandMixin(ListsCommandMixin):
             many of the options work on multiple keys that can exist on
             multiple servers.
         """
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches,too-complex
         if ((start is None and num is not None)
                 or (start is not None and num is None)):
             raise RedisError(

--- a/yaaredis/connection.py
+++ b/yaaredis/connection.py
@@ -211,7 +211,7 @@ class PythonParser(BaseParser):
         return self._buffer and bool(self._buffer.length)
 
     async def read_response(self):
-        # pylint: disable=too-many-branches
+        # pylint: disable=too-many-branches,too-complex
         if not self._buffer:
             raise ConnectionError('Socket closed on remote end')
         response = await self._buffer.readline()

--- a/yaaredis/nodemanager.py
+++ b/yaaredis/nodemanager.py
@@ -110,7 +110,7 @@ class NodeManager:
         correctly covered all slots or when one node is reached and it could
         execute CLUSTER SLOTS command.
         """
-        # pylint: disable=too-many-locals,too-many-nested-blocks
+        # pylint: disable=too-many-locals,too-many-nested-blocks,too-complex
         # pylint: disable=too-many-branches,too-many-statements
         nodes_cache = {}
         tmp_slots = {}

--- a/yaaredis/pipeline.py
+++ b/yaaredis/pipeline.py
@@ -154,7 +154,7 @@ class BasePipeline:
         return self
 
     async def _execute_transaction(self, connection, commands, raise_on_error):
-        # pylint: disable=too-many-locals,too-many-branches
+        # pylint: disable=too-many-locals,too-many-branches,too-complex
         cmds = chain([(('MULTI',), {})], commands, [(('EXEC',), {})])
         all_cmds = connection.pack_commands([args for args, _ in cmds])
         await connection.send_packed_command(all_cmds)
@@ -440,6 +440,7 @@ class StrictClusterPipeline(StrictRedisCluster):
 
     @clusterdown_wrapper
     async def send_cluster_transaction(self, stack, raise_on_error=True):
+        # pylint: disable=too-complex
         # the first time sending the commands we send all of the commands that were queued up.
         # if we have to run through it again, we only retry the commands that failed.
         attempt = sorted(stack, key=lambda x: x.position)
@@ -498,6 +499,7 @@ class StrictClusterPipeline(StrictRedisCluster):
         `allow_redirections` If the pipeline should follow `ASK` & `MOVED` responses
         automatically. If set to false it will raise RedisClusterException.
         """
+        # pylint: disable=too-complex
         # the first time sending the commands we send all of the commands that were queued up.
         # if we have to run through it again, we only retry the commands that failed.
         attempt = sorted(stack, key=lambda x: x.position)

--- a/yaaredis/pool.py
+++ b/yaaredis/pool.py
@@ -86,7 +86,7 @@ class ConnectionPool:
         Invalid types cause a ``UserWarning`` to be raised.
         In the case of conflicting arguments, querystring arguments always win.
         """
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals,too-complex
         url = urlparse(url)
         qs = url.query
 


### PR DESCRIPTION
[VAE-2155](https://dialpad.atlassian.net/browse/VAE-2155)

Enable cyclomatic complexity plugin, which uses the McCabe Cyclomatic complexity to define how complex a function is. By default the maximum cyclomatic complexity is `10`.

[Cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) is the number of linearly independent paths within it, or in layman's terms: how many paths can be taken "through the code". A cyclomatic complexity of `10` means there's 10 linearly independent paths to exit a function.